### PR TITLE
Bump dotnet version to 2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2-sdk as dotnet-build
+FROM microsoft/dotnet:2.1-sdk as dotnet-build
 WORKDIR /dotnet/STS
 
 COPY . .
@@ -6,7 +6,7 @@ COPY . .
 RUN dotnet restore
 RUN dotnet publish -c Release -o out -r linux-x64
 
-FROM microsoft/dotnet:2-runtime-jessie
+FROM microsoft/dotnet:2.1-runtime-stretch-slim
 WORKDIR /Volumes/STS
 COPY --from=dotnet-build /dotnet/STS/out .
 ENTRYPOINT ["dotnet", "STS.dll"]

--- a/STS.csproj
+++ b/STS.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="UI" />
@@ -11,7 +11,7 @@
     <PackageReference Include="DotNetEnv" Version="1.0.1" />
     <PackageReference Include="IdentityServer4" Version="2.0.0-rc1-update1" />
     <PackageReference Include="JWT" Version="5.0.0-beta4" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0" />
     <PackageReference Include="MongoDB.Bson" Version="2.4.4" />
     <PackageReference Include="MongoDB.Driver" Version="2.4.4" />
     <PackageReference Include="MongoDB.Driver.Core" Version="2.4.4" />


### PR DESCRIPTION
Needed to update to 2.1 so the Mongodb driver is compatible with Atlas Clusters Free Tier.

